### PR TITLE
Use write buffer when writing resulting image

### DIFF
--- a/command/args.go
+++ b/command/args.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"io"
+	"bufio"
 	"io/ioutil"
 	"reflect"
 	"encoding/hex"
@@ -147,9 +148,12 @@ func (argOutImageType) prepare(arg string) (out *argout, err error) {
 	if err != nil {
 		return nil, err
 	}
+	// Use 10MB write buffer (should be configurable)
+	bufw := bufio.NewWriterSize(f,10485760)
 	out = new(argout)
-	out.obj = reflect.ValueOf(f)
+	out.obj = reflect.ValueOf(bufw)
 	out.deferfunc = func() {
+		bufw.Flush()
 		f.Close()
 	}
 	return out, nil


### PR DESCRIPTION
This modification resulted in large performance gain on my system (5x faster). Reasoning behind this change is that we should not call the kernel with each sector (512b) and instead accumulate more data before sending it.

Please review the change carefully, this is my first encounter with golang and I do not understand it very well (but I used this code to successfully recover my 2T WD drive)